### PR TITLE
Implement the PATCH /games/{gameId} endpoint to update a game with guessed location input.

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -92,3 +92,7 @@ The backend server will be accessible at `http://localhost:3000/`.
 ### [GET /game/{gameId}]([api-endpoint.yaml](https://github.com/LizzColDev/geoventure/blob/cbd792b58d93c9db29e58ca73dae851277f61460/docs/api-endpoints.yaml#L134))
 
 [Click here](https://github.com/LizzColDev/geoventure/blob/cbd792b58d93c9db29e58ca73dae851277f61460/docs/api-endpoints.yaml#L134) to view the API endpoint configuration.
+
+### [PATCH /game/{gameId}]([api-endpoint.yaml](https://github.com/LizzColDev/geoventure/blob/28b0fb9c17da65b350186808c97fcd92d5fe7032/docs/api-endpoints.yaml#L152))
+
+[Click here](https://github.com/LizzColDev/geoventure/blob/28b0fb9c17da65b350186808c97fcd92d5fe7032/docs/api-endpoints.yaml#L152) to view the API endpoint configuration.

--- a/backend/src/controllers/gamesController.ts
+++ b/backend/src/controllers/gamesController.ts
@@ -91,3 +91,26 @@ export const getGameById =async (req:Request, res: Response, next: NextFunction)
     next(error);
   }
 }
+
+export const updateGameById =async (req:Request, res: Response, next: NextFunction) => {
+
+    try {
+      const {gameId} = req.params;
+      const gameDoc = await db.collection('games').doc(gameId).get();
+      
+      if (!gameDoc.exists) {
+        return next(createError(404, `Game ${gameId} not found`));
+      }
+
+      const currentTime = Date.now();     
+      const gameData = {endTime: currentTime, ...gameDoc.data()};
+
+      await db.collection('games').doc(gameId).set(gameData)
+
+      res.status(201).json({id: gameDoc.id, ...gameData });
+
+      console.log(`Game updated successfully - Game ID: ${gameDoc.id}`);
+    } catch (error) {
+      next(error);
+    }
+}

--- a/backend/src/routes/games.ts
+++ b/backend/src/routes/games.ts
@@ -1,10 +1,10 @@
 import express from 'express';
-import { createGame, getGames, getGameById } from '../controllers/gamesController';
+import { createGame, getGames, getGameById, updateGameById } from '../controllers/gamesController';
 
 const gamesRouter = express.Router();
 
 gamesRouter.post('/game', createGame);
 gamesRouter.get('/games', getGames);
 gamesRouter.get('/game/:gameId', getGameById);
-
+gamesRouter.patch('/game/:gameId', updateGameById);
 export default gamesRouter;

--- a/backend/tests/controllers/firebaseMock.ts
+++ b/backend/tests/controllers/firebaseMock.ts
@@ -11,6 +11,7 @@ export const createFirebaseMock = () => ({
       doc: (docId: string) => ({
         get: getByIdMock.bind(null, docId, collectionName),
         delete: deleteMock,
+        set: updateByIdMock.bind(null, docId),
       }),
     }),
   }),
@@ -85,4 +86,21 @@ export const deleteMock = jest.fn(() => Promise.resolve());
 
 export const addGameMock = jest.fn(() => {
   return Promise.resolve({ id: "idTestGame", userId: "user1", initialTime: 12345 });
+});
+
+export const updateByIdMock = jest.fn( async (docId) => {
+  
+  if(docId){
+    return { 
+      exists: true,
+      id: docId, 
+      data: () => ( {
+        userId: "user1", 
+        initialTime: expect.any(Number), 
+        endTime: expect.any(Number)
+      })
+    };
+  } else {
+    throw new Error(`Game ${docId} not found`);
+  }
 });

--- a/backend/tests/controllers/firebaseMock.ts
+++ b/backend/tests/controllers/firebaseMock.ts
@@ -88,8 +88,8 @@ export const addGameMock = jest.fn(() => {
   return Promise.resolve({ id: "idTestGame", userId: "user1", initialTime: 12345 });
 });
 
-export const updateByIdMock = jest.fn( async (docId) => {
-  
+export const updateByIdMock = jest.fn( async (docId, latitude, longitude) => {
+
   if(docId){
     return { 
       exists: true,
@@ -97,7 +97,8 @@ export const updateByIdMock = jest.fn( async (docId) => {
       data: () => ( {
         userId: "user1", 
         initialTime: expect.any(Number), 
-        endTime: expect.any(Number)
+        endTime: expect.any(Number),
+        estimatedLocation: { latitude: latitude, longitude: longitude }
       })
     };
   } else {

--- a/backend/tests/controllers/gamesControllers.test.ts
+++ b/backend/tests/controllers/gamesControllers.test.ts
@@ -216,6 +216,7 @@ describe("Games Controllers - PATCH /game/:gameId", () => {
       params: {
         gameId: "game1",
       },
+      body: { latitude: 40.7128, longitude: -74.0060 },
     } as unknown as Request;
     res = {
       status: jest.fn().mockReturnThis(),
@@ -231,13 +232,15 @@ describe("Games Controllers - PATCH /game/:gameId", () => {
 
   it("should respond with the updated game data", async () => {
     await updateGameById(req, res, next);
-
-    expect(updateByIdMock).toHaveBeenCalledWith("game1", {
-      endTime: expect.any(Number),
-      userId: 'user1',
-      initialTime: expect.any(Number),
-    });
-
+    const { latitude, longitude } = req.body;
+    expect(updateByIdMock).toHaveBeenCalledWith(
+      "game1",
+      {
+        "endTime": expect.any(Number), 
+        "estimatedLocation": {"latitude": 40.7128, "longitude": -74.006}, 
+        "initialTime": expect.any(Number), 
+        "userId": "user1"}
+    );
     
     // Assert the response status, JSON, and next not being called
     expect(res.status).toHaveBeenCalledWith(201);
@@ -245,11 +248,31 @@ describe("Games Controllers - PATCH /game/:gameId", () => {
       id: "game1", 
       initialTime: expect.any(Number),
       endTime: expect.any(Number),
-      userId: "user1"
+      userId: "user1",
+      estimatedLocation: { latitude, longitude } 
     });
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('should handle invalid latitude or longitude', async () => {
+    // Test data with invalid coordinates
+    const req: any = { params: { gameId: 'game1' }, body: {} };
+
+    const res: any = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const next = jest.fn();
+  
+    // Function call
+    await updateGameById(req, res, next);
+  
+    // Verification of function calls and results
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+  
   it('should handle game not found error', async () => {
     getByIdMock.mockImplementationOnce(async () => ({
       exists: false,


### PR DESCRIPTION
### Description

This pull request introduces a new PATCH endpoint in the "games" folder that allows users to update a game with their guessed location. The guessed location information, including latitude and longitude, will be provided in the request payload.

### Related Issue

[Feature 9: Implement the PATCH /games/{gameId} endpoint to update a game with guessed location input.](https://github.com/LizzColDev/geoventure/issues/9#issue-1829655413)

### Checklist

- [x] Developed comprehensive unit tests following TDD principles.
- [x] New PATCH endpoint added for updating guessed location.
- [x] Endpoint retrieves game information by their unique identifier (gameId).
- [x] Achieved over 80% test coverage.
- [x] Updated the README, with the GET/game/{gameId} endpoint.
- [x] Docker support integrated for the new endpoint.
- [x] API works seamlessly within a Docker image.