### PR TITLE
Updated Docker Compose for volume handling in fastapi and backend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,25 @@
+# Exclude common Node.js files and directories
+node_modules/
+npm-debug.log
+
+# Exclude TypeScript-related files
+*.tsbuildinfo
+*.js.map
+
+# Exclude any temporary or build files
+*.swp
+*.log
+*.tmp
+
+# Exclude IDE-specific files
+.vscode/
+.idea/
+
+# Exclude any local development files
+.env
+
+# Exclude the Dockerignore file itself
+.dockerignore
+
+# Exclude sensitive files
+key.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,15 +1,22 @@
 FROM node:19.4.0
 
+# Set the working directory in the container
 WORKDIR /app
 
+# Copy package.json and package-lock.json to the working directory
 COPY package*.json ./
-COPY ./ ./
-COPY key.json key.json
-COPY tsconfig.json tsconfig.json
-RUN npm install
-RUN npm install -g ts-node-dev
-RUN npm run build
 
+# Install app dependencies
+RUN npm install
+
+# Copy tsconfig.json (and any other necessary configuration files)
+COPY tsconfig.json .
+
+# Copy the rest of the application code
+COPY ./ ./
+
+# Expose the port the app runs on
 EXPOSE 3000
 
+# Define the default command to run the application
 CMD ["npm", "run", "dev"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,8 +7,9 @@ COPY ./ ./
 COPY key.json key.json
 COPY tsconfig.json tsconfig.json
 RUN npm install
+RUN npm install -g ts-node-dev
 RUN npm run build
 
 EXPOSE 3000
 
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "dev"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "build": "npx tsc",
     "start": "node dist/src/index.js",
     "dev": "npm-run-all -p build dev:server",
-    "dev:server": "wait-on dist/src/index.js && ts-node --transpile-only --files dist/src/index.js",
+    "dev:server": "ts-node-dev --respawn --transpile-only --files src/index.ts",
     "test": "jest --coverage"
   },
   "author": "",
@@ -19,23 +19,18 @@
     "@types/http-errors": "^2.0.1",
     "express": "^4.18.2",
     "firebase-admin": "^11.10.1",
-    "http-errors": "^2.0.0",
-    "uuid": "^9.0.0"
+    "http-errors": "^2.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.3",
     "@types/node": "^20.4.5",
-    "@types/supertest": "^2.0.12",
-    "@types/uuid": "^9.0.2",
     "dotenv": "^16.3.1",
-    "firestore-jest-mock": "^0.21.0",
     "jest": "^29.6.2",
     "npm-run-all": "^4.1.5",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.1.6",
-    "wait-on": "^7.0.1"
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.1.6"
   }
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -27,7 +27,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
@@ -106,5 +106,13 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": [
+    "src/**/*.ts",
+    "tsconfig.json"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,10 +6,13 @@ services:
       context: ./fastApi
       dockerfile: Dockerfile
     container_name: fastapi-app
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/key.json
     ports:
       - "8000:8000"
     volumes:
       - ./fastApi:/app:rw
+      - ./fastApi/key.json:/app/key.json:ro
 
   backend:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./fastApi:/app/fastApi:rw
+      - ./fastApi:/app:rw
 
   backend:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,10 +15,13 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+    command: npm run dev
     container_name: geoventure-backend-app
     environment:
       - FIREBASE_KEY_JSON_PATH=./key.json
     ports:
       - "3000:3000"
     volumes:
-      - ./backend:/app/backend:rw
+      - ./backend:/app:rw
+      - /app/node_modules
+      - /app/dist

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,13 +18,12 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    command: npm run dev
     container_name: geoventure-backend-app
-    environment:
-      - FIREBASE_KEY_JSON_PATH=./key.json
     ports:
       - "3000:3000"
     volumes:
       - ./backend:/app:rw
+      - ./backend/key.json:/app/key.json:ro
       - /app/node_modules
       - /app/dist
+    working_dir: /app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - .:/fastApi:ro
+      - ./fastApi:/app/fastApi:rw
 
   backend:
     build:
@@ -20,3 +20,5 @@ services:
       - FIREBASE_KEY_JSON_PATH=./key.json
     ports:
       - "3000:3000"
+    volumes:
+      - ./backend:/app/backend:rw

--- a/fastApi/.dockerignore
+++ b/fastApi/.dockerignore
@@ -21,3 +21,5 @@ poetry.lock
 
 # Exclude the Dockerignore file itself
 .dockerignore
+
+key.json

--- a/fastApi/database/firestore.py
+++ b/fastApi/database/firestore.py
@@ -1,9 +1,10 @@
+import os
 import firebase_admin
 from firebase_admin import credentials
 from firebase_admin import firestore
 from fastapi import HTTPException
 
-cred = credentials.Certificate('./key.json')
+cred = credentials.Certificate(os.environ['GOOGLE_APPLICATION_CREDENTIALS'])
 firebase_admin.initialize_app(cred)
 
 db = firestore.client()

--- a/fastApi/main.py
+++ b/fastApi/main.py
@@ -10,4 +10,4 @@ for router, options in api_routers:
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Pull Request: Implement Volumes and Docker Configuration

### Description
This pull request addresses the issue [Docker-compose Volumes #16](https://github.com/LizzColDev/geoventure/issues/16#issue-1844218676). It implements volume configurations in the Docker Compose file to exclude unnecessary data from runner containers, specifically the `node_modules` and `dist` folders. Additionally, it adjusts the handling of the `key.json` file and includes a `.dockerignore` file to prevent unnecessary files and folders from being included in the Docker build context.

### Checklist
- [x] Updated `docker-compose.yaml` for `fastapi` service with volume configurations.
- [x] Updated `docker-compose.yaml` for `backend` service with volume configurations.
- [x] Adjusted volume settings to exclude unnecessary data.
- [x] Specified `GOOGLE_APPLICATION_CREDENTIALS` for the `fastapi` service.
- [x] Added volume configurations for the `key.json` file in both services.
- [x] Created a `.dockerignore` file.
- [x] Verified and tested changes locally.
